### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,1 @@
 .refcache/
-draft-cpaasch-ippm-responsiveness.html
-draft-cpaasch-ippm-responsiveness.xml
-draft-cpaasch-ippm-responsiveness.txt
-draft-cpaasch-ippm-responsiveness.ps
-draft-cpaasch-ippm-responsiveness.pdf


### PR DESCRIPTION
It was a mistake to `.gitignore` the outputs of `make all` - there's no reference for others to point to. This checkin preserves the resulting .txt, .pdf, .xml, .ps, and .html files.